### PR TITLE
Collect constant from rust-bitcoin projects into one library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target
+**/*.rs.bk
+Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: rust
+rust:
+  - nightly
+  - beta
+  - stable
+  - 1.14.0 # rustc on debian stable
+cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,19 +3,11 @@ name = "bitcoin-constants"
 version = "0.1.0"
 authors = ["The rust-bitcoin developers"]
 repository = "https://github.com/rust-bitcoin/bitcoin-constants"
-description = "Contains network constants for bitcoin and similiar crypto currencies"
+description = "Contains network constants for bitcoin"
 readme = "README.md"
 keywords = ["bitcoin", "constants", "blockchain"]
 categories = []
 license = "MIT"
 
-[features]
-default = ["serde-support"]
-serde-support = ["serde"]
-
 [dependencies]
-serde = { version = "0.6", optional = true }
 bitcoin_hashes = {git = "https://github.com/rust-bitcoin/bitcoin_hashes.git"}
-
-[dev-dependencies]
-serde_json = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bitcoin-constants"
+version = "0.1.0"
+authors = ["The rust-bitcoin developers"]
+repository = "https://github.com/rust-bitcoin/bitcoin-constants"
+description = "Contains network constants for bitcoin and similiar crypto currencies"
+readme = "README.md"
+keywords = ["bitcoin", "constants", "blockchain"]
+categories = []
+license = "MIT"
+
+[features]
+default = ["serde-support"]
+serde-support = ["serde"]
+
+[dependencies]
+serde = { version = "0.6", optional = true }
+
+[dev-dependencies]
+serde_json = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde-support = ["serde"]
 
 [dependencies]
 serde = { version = "0.6", optional = true }
+bitcoin_hashes = {git = "https://github.com/rust-bitcoin/bitcoin_hashes.git"}
 
 [dev-dependencies]
 serde_json = "0.6"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # bitcoin-constants
-Constants used across Bitcoin libraries
+This library provides various constants for different bitcoin-like cryptocurrency networks.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,229 @@
+// Copyright (c) 2017 Clark Moody
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//! Constants for various bitcoin-like cryptocurrencie networks.
+//!
+//! The data provided for each currency includes:
+//! * the human readable part as authoritatively maintained in [SLIP-0173](https://github.com/satoshilabs/slips/blob/master/slip-0173.md)
+//! * the network's magic bytes as defined in their respective git repository
+
+#![deny(missing_docs)]
+#![deny(non_upper_case_globals)]
+#![deny(non_camel_case_types)]
+#![deny(non_snake_case)]
+#![deny(unused_mut)]
+
+#[cfg(feature = "serde-support")]
+extern crate serde;
+
+#[cfg(all(feature = "serde-support", test))]
+extern crate serde_json;
+
+use std::fmt;
+use std::str::FromStr;
+
+/// The cryptocurrency to act on
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum Network {
+    /// Bitcoin mainnet
+    Bitcoin,
+    /// Bitcoin testnet
+    Testnet,
+    /// Litecoin mainnet
+    Litecoin,
+    /// Litecoin testnet
+    LitecoinTestnet,
+    /// Vertcoin mainnet
+    Vertcoin,
+    /// Vertcoin testnet
+    VertcoinTestnet,
+
+    // if you add networks please also include them in the ALL_NETWORKS list
+}
+
+/// List of all networks included in this crate
+//
+// Given a list of all networks and any `network -> x` mapping, the inverse `x -> network` mapping
+// can be calculated. This might not be the most performant solution, but surely the easiest to
+// maintain. Since the match statements for the `network -> x` mapping have to be complete the
+// compiler will complain if one of the mappings was forgotten after adding a new currency which is
+// not possible for `x -> network` mappings.
+pub const ALL_NETWORKS: &'static [Network] = &[
+    Network::Bitcoin,
+    Network::Testnet,
+    Network::Litecoin,
+    Network::LitecoinTestnet,
+    Network::Vertcoin,
+    Network::VertcoinTestnet
+];
+
+impl Network {
+    /// Returns the Human-readable part for the given network
+    pub fn hrp(&self) -> &'static str {
+        match *self {
+            Network::Bitcoin => "bc",
+            Network::Testnet => "tb",
+            Network::Litecoin => "ltc",
+            Network::LitecoinTestnet => "tltc",
+            Network::Vertcoin => "vtc",
+            Network::VertcoinTestnet => "tvtc",
+        }
+    }
+
+    /// Classify a Human-readable part as its cryptocurrency
+    pub fn from_hrp(hrp: &str) -> Option<Network> {
+        Network::find_net_with_property(|n| n.hrp() == hrp)
+    }
+
+    /// Returns the network's magic bytes
+    pub fn magic(&self) -> u32 {
+        match *self {
+            // https://github.com/bitcoin/bitcoin/blob/ce650182f4d9847423202789856e6e5f499151f8/src/chainparams.cpp#L115
+            Network::Bitcoin => 0xD9B4BEF9,
+            Network::Testnet => 0x0709110B,
+
+            // https://github.com/litecoin-project/litecoin/blob/42dddc2f9ef5bdc8369a3c7552e70b974b9d1764/src/chainparams.cpp#L114
+            Network::Litecoin => 0xDBB6C0FB,
+            Network::LitecoinTestnet => 0xF1C8D2FD,
+
+            // https://github.com/vertcoin-project/vertcoin-core/blob/3b3701e7a76d4fe6d2d7459b6f39a9570ca65b19/src/chainparams.cpp#L114
+            Network::Vertcoin => 0xDAB5BFFA,
+            Network::VertcoinTestnet => 0x74726576,
+        }
+    }
+
+    /// Constructs a network from magic bytes if possible
+    pub fn from_magic(magic: u32) -> Option<Network> {
+        Network::find_net_with_property(|n| n.magic() == magic)
+    }
+
+    fn find_net_with_property<P>(predicate: P) -> Option<Network>
+        where for<'r> P: FnMut(&'r &Network) -> bool
+    {
+        ALL_NETWORKS.iter().find::<P>(predicate).map(|n| *n)
+    }
+}
+
+impl fmt::Display for Network {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let name = match *self {
+            Network::Bitcoin => "bitcoin",
+            Network::Testnet => "testnet", // only 'testnet' for compatibility reasons
+            Network::Litecoin => "litecoin",
+            Network::LitecoinTestnet => "litecoin-testnet",
+            Network::Vertcoin => "vertcoin",
+            Network::VertcoinTestnet => "vertcoin-testnet",
+        };
+        write!(f, "{}", name)
+    }
+}
+
+impl fmt::Debug for Network {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl FromStr for Network {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match Network::find_net_with_property(|n| &n.to_string() == s) {
+            Some(network) => Ok(network),
+            None => Err(())
+        }
+    }
+}
+
+#[cfg(feature = "serde-support")]
+impl serde::Deserialize for Network {
+    #[inline]
+    fn deserialize<D>(d: &mut D) -> Result<Network, D::Error>
+        where D: serde::Deserializer
+    {
+        struct Visitor;
+        impl serde::de::Visitor for Visitor {
+            type Value = Network;
+
+            fn visit_string<E>(&mut self, v: String) -> Result<Network, E>
+                where E: serde::de::Error
+            {
+                self.visit_str(&v)
+            }
+
+            fn visit_str<E>(&mut self, s: &str) -> Result<Network, E>
+                where E: serde::de::Error
+            {
+                match s.parse::<Network>() {
+                    Ok(network) => Ok(network),
+                    Err(()) => Err(serde::de::Error::syntax("Network"))
+                }
+            }
+        }
+
+        d.visit(Visitor)
+    }
+}
+
+#[cfg(feature = "serde-support")]
+impl serde::Serialize for Network {
+    fn serialize<S>(&self, s: &mut S) -> Result<(), S::Error>
+        where S: ::serde::Serializer
+    {
+        s.visit_str(&self.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use Network;
+
+    #[test]
+    fn hrp_conversion() {
+        assert_eq!(Network::Bitcoin.hrp(), "bc");
+        assert_eq!(Network::from_hrp("tvtc"), Some(Network::VertcoinTestnet));
+        assert_eq!(Network::from_hrp("test"), None);
+    }
+
+    #[test]
+    fn magic_conversion() {
+        assert_eq!(Network::Bitcoin.magic(), 0xD9B4BEF9);
+        assert_eq!(Network::from_magic(0xD9B4BEF9), Some(Network::Bitcoin));
+        assert_eq!(Network::from_magic(0xABCDEF01), None);
+    }
+
+    #[test]
+    fn enum_name_conversion() {
+        assert_eq!(Network::Bitcoin.to_string(), "bitcoin".to_string());
+        assert_eq!("testnet".parse(), Ok(Network::Testnet));
+        assert_eq!("foobar".parse::<Network>(), Err(()));
+    }
+
+    #[cfg(feature = "serde-support")]
+    #[test]
+    fn test_serde() {
+        let from = vec![Network::Bitcoin, Network::LitecoinTestnet, Network::Vertcoin];
+        let enc = ::serde_json::to_string(&from).unwrap();
+        assert!(enc.contains("bitcoin"));
+        assert!(enc.contains("litecoin-testnet"));
+        assert!(enc.contains("vertcoin"));
+        assert_eq!(::serde_json::from_str::<Vec<Network>>(&enc).unwrap(), from);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,12 +40,15 @@
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
 
+extern crate bitcoin_hashes;
+
 #[cfg(feature = "serde-support")]
 extern crate serde;
 
 #[cfg(all(feature = "serde-support", test))]
 extern crate serde_json;
 
+use bitcoin_hashes::sha256d::Sha256dHash;
 use std::fmt;
 
 /// Provides network constants for one or more possible p2p networks. This trait is intended to be
@@ -95,6 +98,9 @@ pub trait NetworkConstants : Sized {
 
     /// Returns parameters for the chain's consensus
     fn chain_params(&self) -> ChainParams<Self>;
+
+    /// Returns the hash of the genesis block
+    fn genesis_block(&self) -> Sha256dHash;
 }
 
 /// Errors that can happen in the `from_` functions
@@ -334,6 +340,26 @@ impl NetworkConstants for Networks {
                 allow_min_difficulty_blocks: true,
                 no_pow_retargeting: true,
             },
+            _ => unimplemented!(),
+        }
+    }
+
+    fn genesis_block(&self) -> Sha256dHash {
+        use bitcoin_hashes::hex::FromHex;
+
+        match *self {
+            Networks::Bitcoin => Sha256dHash::from_hex(
+                "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+            ).unwrap(),
+
+            Networks::Testnet => Sha256dHash::from_hex(
+                "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
+            ).unwrap(),
+
+            Networks::Regtest => Sha256dHash::from_hex(
+                "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
+            ).unwrap(),
+
             _ => unimplemented!(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,15 @@ pub trait NetworkConstants : Sized {
     /// Tries to find a network with maching hrp
     fn from_hrp(hrp: &str) -> Result<Self, Error>;
 
+    /// Returns the prefix byte for legacy p2pk addresses
+    fn p2pk_prefix(&self) -> u8;
+
+    /// Returns the prefix byte for legacy p2pkh addresses
+    fn p2pkh_prefix(&self) -> u8;
+
+    /// Returns the prefix byte for legacy p2sh addresses
+    fn p2sh_prefix(&self) -> u8;
+
     /// Returns the network's magic bytes
     fn magic(&self) -> u32;
 
@@ -229,6 +238,26 @@ impl NetworkConstants for Networks {
 
     fn from_hrp(hrp: &str) -> Result<Networks, Error> {
         Networks::find_net_with_property(|n| n.hrp() == hrp)
+    }
+
+    fn p2pk_prefix(&self) -> u8 {
+        match *self {
+            Networks::Bitcoin => 0,
+            Networks::Testnet | Networks::Regtest => 111,
+            _ => unimplemented!(),
+        }
+    }
+
+    fn p2pkh_prefix(&self) -> u8 {
+        self.p2pk_prefix()
+    }
+
+    fn p2sh_prefix(&self) -> u8 {
+        match *self {
+            Networks::Bitcoin => 5,
+            Networks::Testnet | Networks::Regtest => 196,
+            _ => unimplemented!(),
+        }
     }
 
     fn magic(&self) -> u32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,4 +201,23 @@ mod tests {
             assert!(format!("{:?}", n).contains(n.name()));
         }
     }
+
+    #[test]
+    fn dont_panic() {
+        for n in all_networks() {
+            let _ = n.hrp();
+            let _ = n.p2pk_prefix();
+            let _ = n.p2pkh_prefix();
+            let _ = n.p2sh_prefix();
+            let _ = n.xpub_prefix();
+            let _ = n.xpriv_prefix();
+            let _ = n.wif_prefix();
+            let _ = n.magic();
+            let _ = n.name();
+            let _ = n.network_type();
+            let _ = n.chain_params();
+            let _ = n.genesis_block();
+            let _ = n.clone_boxed();
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Clark Moody
+// Copyright (c) 2018 The rust-bitcoin developers
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,10 @@
 //! The data provided for each currency includes:
 //! * the human readable part as authoritatively maintained in [SLIP-0173](https://github.com/satoshilabs/slips/blob/master/slip-0173.md)
 //! * the network's magic bytes as defined in their respective git repository
+//!
+//! PRs adding new networks for the existing currencies (e.g. regtest) and constants not yet
+//! included are very welcome. Please provide credible sources for magic bytes etc. in comments
+//! to make review easier.
 
 #![deny(missing_docs)]
 #![deny(non_upper_case_globals)]
@@ -37,11 +41,76 @@ extern crate serde;
 extern crate serde_json;
 
 use std::fmt;
-use std::str::FromStr;
+
+/// Provides network constants for one or more possible p2p networks. This trait is intended to be
+/// implemented for enums representing sub- or supersets of the networks included in `Networks`.
+/// When taking network-enums as arguments for functions please try to implement these generically
+/// for this trait, e.g.:
+///
+/// ```ignore
+/// use NetworkConstants;
+///
+/// fn new_address(network: &NetworkConstants) -> String {
+///     let bech32_prefix = network.hrp();
+///     // more bech32 magic
+///     unimplemented!()
+/// }
+///
+/// fn network_from_address<N: NetworkConstants>(bech32_addr: &str) -> Option<N> {
+///     // bech32 parsing magic
+///     let hrp = "bc";
+///     N::from_hrp(hrp).ok()
+/// }
+/// ```
+///
+/// If you feel the urge to do matching over an enum implementing `NetworkConstants` please
+/// consider opening a PR instead if your problem/solution can be generalized.
+pub trait NetworkConstants : Sized {
+    /// Returns the Human-readable part for the given network
+    fn hrp(&self) -> &'static str;
+
+    /// Tries to find a network with maching hrp
+    fn from_hrp(hrp: &str) -> Result<Self, Error>;
+
+    /// Returns the network's magic bytes
+    fn magic(&self) -> u32;
+
+    /// Tries to find a network with matching magic bytes
+    fn from_magic(magic: u32) -> Result<Self, Error>;
+
+    /// Returns a string representation of the networks identity (a.k.a. name)
+    fn name(&self) -> &'static str;
+
+    /// Tries to find a network with a matching name
+    fn from_name(name: &str) -> Result<Self, Error>;
+
+    /// Describes the nature of the network (production/testing)
+    fn network_type(&self) -> NetworkType;
+}
+
+/// Errors that can happen in the `from_` functions
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Error {
+    /// Not network with the specified properties (e.g. matching name) could be found.
+    UnknownNetwork,
+}
+
+/// Describes the nature of the network
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum NetworkType {
+    /// Public production network with real economic activity
+    Mainnet,
+
+    /// Public network without real economic activity, for testing purposes only
+    Testnet,
+
+    /// Private testnet, typically created and controlled by a single actor
+    Regtest,
+}
 
 /// The cryptocurrency to act on
 #[derive(PartialEq, Eq, Clone, Copy)]
-pub enum Network {
+pub enum Networks {
     /// Bitcoin mainnet
     Bitcoin,
     /// Bitcoin testnet
@@ -65,115 +134,118 @@ pub enum Network {
 // maintain. Since the match statements for the `network -> x` mapping have to be complete the
 // compiler will complain if one of the mappings was forgotten after adding a new currency which is
 // not possible for `x -> network` mappings.
-pub const ALL_NETWORKS: &'static [Network] = &[
-    Network::Bitcoin,
-    Network::Testnet,
-    Network::Litecoin,
-    Network::LitecoinTestnet,
-    Network::Vertcoin,
-    Network::VertcoinTestnet
+pub const ALL_NETWORKS: &'static [Networks] = &[
+    Networks::Bitcoin,
+    Networks::Testnet,
+    Networks::Litecoin,
+    Networks::LitecoinTestnet,
+    Networks::Vertcoin,
+    Networks::VertcoinTestnet
 ];
 
-impl Network {
-    /// Returns the Human-readable part for the given network
-    pub fn hrp(&self) -> &'static str {
+impl Networks {
+    fn find_net_with_property<P>(predicate: P) -> Result<Networks, Error>
+        where for<'r> P: FnMut(&'r &Networks) -> bool
+    {
+        match ALL_NETWORKS.iter().find::<P>(predicate).map(|n| *n) {
+            Some(network) => Ok(network),
+            None => Err(Error::UnknownNetwork)
+        }
+    }
+}
+
+impl NetworkConstants for Networks {
+    fn hrp(&self) -> &'static str {
         match *self {
-            Network::Bitcoin => "bc",
-            Network::Testnet => "tb",
-            Network::Litecoin => "ltc",
-            Network::LitecoinTestnet => "tltc",
-            Network::Vertcoin => "vtc",
-            Network::VertcoinTestnet => "tvtc",
+            Networks::Bitcoin => "bc",
+            Networks::Testnet => "tb",
+            Networks::Litecoin => "ltc",
+            Networks::LitecoinTestnet => "tltc",
+            Networks::Vertcoin => "vtc",
+            Networks::VertcoinTestnet => "tvtc",
         }
     }
 
-    /// Classify a Human-readable part as its cryptocurrency
-    pub fn from_hrp(hrp: &str) -> Option<Network> {
-        Network::find_net_with_property(|n| n.hrp() == hrp)
+    fn from_hrp(hrp: &str) -> Result<Networks, Error> {
+        Networks::find_net_with_property(|n| n.hrp() == hrp)
     }
 
-    /// Returns the network's magic bytes
-    pub fn magic(&self) -> u32 {
+    fn magic(&self) -> u32 {
         match *self {
             // https://github.com/bitcoin/bitcoin/blob/ce650182f4d9847423202789856e6e5f499151f8/src/chainparams.cpp#L115
-            Network::Bitcoin => 0xD9B4BEF9,
-            Network::Testnet => 0x0709110B,
+            Networks::Bitcoin => 0xD9B4BEF9,
+            Networks::Testnet => 0x0709110B,
 
             // https://github.com/litecoin-project/litecoin/blob/42dddc2f9ef5bdc8369a3c7552e70b974b9d1764/src/chainparams.cpp#L114
-            Network::Litecoin => 0xDBB6C0FB,
-            Network::LitecoinTestnet => 0xF1C8D2FD,
+            Networks::Litecoin => 0xDBB6C0FB,
+            Networks::LitecoinTestnet => 0xF1C8D2FD,
 
             // https://github.com/vertcoin-project/vertcoin-core/blob/3b3701e7a76d4fe6d2d7459b6f39a9570ca65b19/src/chainparams.cpp#L114
-            Network::Vertcoin => 0xDAB5BFFA,
-            Network::VertcoinTestnet => 0x74726576,
+            Networks::Vertcoin => 0xDAB5BFFA,
+            Networks::VertcoinTestnet => 0x74726576,
         }
     }
 
     /// Constructs a network from magic bytes if possible
-    pub fn from_magic(magic: u32) -> Option<Network> {
-        Network::find_net_with_property(|n| n.magic() == magic)
+    fn from_magic(magic: u32) -> Result<Networks, Error> {
+        Networks::find_net_with_property(|n| n.magic() == magic)
     }
 
-    fn find_net_with_property<P>(predicate: P) -> Option<Network>
-        where for<'r> P: FnMut(&'r &Network) -> bool
-    {
-        ALL_NETWORKS.iter().find::<P>(predicate).map(|n| *n)
+    fn name(&self) -> &'static str {
+        match *self {
+            Networks::Bitcoin => "bitcoin",
+            Networks::Testnet => "testnet", // only 'testnet' for compatibility reasons
+            Networks::Litecoin => "litecoin",
+            Networks::LitecoinTestnet => "litecoin-testnet",
+            Networks::Vertcoin => "vertcoin",
+            Networks::VertcoinTestnet => "vertcoin-testnet",
+        }
     }
-}
 
-impl fmt::Display for Network {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let name = match *self {
-            Network::Bitcoin => "bitcoin",
-            Network::Testnet => "testnet", // only 'testnet' for compatibility reasons
-            Network::Litecoin => "litecoin",
-            Network::LitecoinTestnet => "litecoin-testnet",
-            Network::Vertcoin => "vertcoin",
-            Network::VertcoinTestnet => "vertcoin-testnet",
-        };
-        write!(f, "{}", name)
+    fn from_name(name: &str) -> Result<Self, Error> {
+        Networks::find_net_with_property(|n| n.name() == name)
     }
-}
 
-impl fmt::Debug for Network {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-impl FromStr for Network {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match Network::find_net_with_property(|n| &n.to_string() == s) {
-            Some(network) => Ok(network),
-            None => Err(())
+    fn network_type(&self) -> NetworkType {
+        match *self {
+            Networks::Bitcoin => NetworkType::Mainnet,
+            Networks::Testnet => NetworkType::Testnet,
+            Networks::Litecoin => NetworkType::Mainnet,
+            Networks::LitecoinTestnet => NetworkType::Testnet,
+            Networks::Vertcoin => NetworkType::Mainnet,
+            Networks::VertcoinTestnet => NetworkType::Testnet,
         }
     }
 }
 
+impl fmt::Debug for Networks {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{}", self.name())
+    }
+}
+
 #[cfg(feature = "serde-support")]
-impl serde::Deserialize for Network {
+impl serde::Deserialize for Networks {
     #[inline]
-    fn deserialize<D>(d: &mut D) -> Result<Network, D::Error>
+    fn deserialize<D>(d: &mut D) -> Result<Networks, D::Error>
         where D: serde::Deserializer
     {
         struct Visitor;
         impl serde::de::Visitor for Visitor {
-            type Value = Network;
+            type Value = Networks;
 
-            fn visit_string<E>(&mut self, v: String) -> Result<Network, E>
+            fn visit_string<E>(&mut self, v: String) -> Result<Networks, E>
                 where E: serde::de::Error
             {
                 self.visit_str(&v)
             }
 
-            fn visit_str<E>(&mut self, s: &str) -> Result<Network, E>
+            fn visit_str<E>(&mut self, s: &str) -> Result<Networks, E>
                 where E: serde::de::Error
             {
-                match s.parse::<Network>() {
+                match Networks::from_name(s) {
                     Ok(network) => Ok(network),
-                    Err(()) => Err(serde::de::Error::syntax("Network"))
+                    Err(Error::UnknownNetwork) => Err(serde::de::Error::syntax("Network")),
                 }
             }
         }
@@ -183,47 +255,47 @@ impl serde::Deserialize for Network {
 }
 
 #[cfg(feature = "serde-support")]
-impl serde::Serialize for Network {
+impl serde::Serialize for Networks {
     fn serialize<S>(&self, s: &mut S) -> Result<(), S::Error>
         where S: ::serde::Serializer
     {
-        s.visit_str(&self.to_string())
+        s.visit_str(self.name())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use Network;
+    use {Networks, Error, NetworkConstants};
 
     #[test]
     fn hrp_conversion() {
-        assert_eq!(Network::Bitcoin.hrp(), "bc");
-        assert_eq!(Network::from_hrp("tvtc"), Some(Network::VertcoinTestnet));
-        assert_eq!(Network::from_hrp("test"), None);
+        assert_eq!(Networks::Bitcoin.hrp(), "bc");
+        assert_eq!(Networks::from_hrp("tvtc"), Ok(Networks::VertcoinTestnet));
+        assert_eq!(Networks::from_hrp("test"), Err(Error::UnknownNetwork));
     }
 
     #[test]
     fn magic_conversion() {
-        assert_eq!(Network::Bitcoin.magic(), 0xD9B4BEF9);
-        assert_eq!(Network::from_magic(0xD9B4BEF9), Some(Network::Bitcoin));
-        assert_eq!(Network::from_magic(0xABCDEF01), None);
+        assert_eq!(Networks::Bitcoin.magic(), 0xD9B4BEF9);
+        assert_eq!(Networks::from_magic(0xD9B4BEF9), Ok(Networks::Bitcoin));
+        assert_eq!(Networks::from_magic(0xABCDEF01), Err(Error::UnknownNetwork));
     }
 
     #[test]
     fn enum_name_conversion() {
-        assert_eq!(Network::Bitcoin.to_string(), "bitcoin".to_string());
-        assert_eq!("testnet".parse(), Ok(Network::Testnet));
-        assert_eq!("foobar".parse::<Network>(), Err(()));
+        assert_eq!(Networks::Bitcoin.name(), "bitcoin".to_string());
+        assert_eq!(Networks::from_name("testnet"), Ok(Networks::Testnet));
+        assert_eq!(Networks::from_name("foobar"), Err(Error::UnknownNetwork));
     }
 
     #[cfg(feature = "serde-support")]
     #[test]
     fn test_serde() {
-        let from = vec![Network::Bitcoin, Network::LitecoinTestnet, Network::Vertcoin];
+        let from = vec![Networks::Bitcoin, Networks::LitecoinTestnet, Networks::Vertcoin];
         let enc = ::serde_json::to_string(&from).unwrap();
         assert!(enc.contains("bitcoin"));
         assert!(enc.contains("litecoin-testnet"));
         assert!(enc.contains("vertcoin"));
-        assert_eq!(::serde_json::from_str::<Vec<Network>>(&enc).unwrap(), from);
+        assert_eq!(::serde_json::from_str::<Vec<Networks>>(&enc).unwrap(), from);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,12 @@ pub trait NetworkConstants : Sized {
     /// Returns the prefix byte for legacy p2sh addresses
     fn p2sh_prefix(&self) -> u8;
 
+    /// Returns the prefix bytes for encoding xpub keys
+    fn xpub_prefix(&self) -> &'static [u8; 4];
+
+    /// Returns the prefix bytes for encoding xpriv keys
+    fn xpriv_prefix(&self) -> &'static [u8; 4];
+
     /// Returns the network's magic bytes
     fn magic(&self) -> u32;
 
@@ -305,6 +311,22 @@ impl NetworkConstants for Networks {
         }
     }
 
+    fn xpub_prefix(&self) -> &'static [u8; 4] {
+        match *self {
+            Networks::Bitcoin => &[0x04u8, 0x88, 0xB2, 0x1E],
+            Networks::Testnet | Networks::Regtest => &[0x04u8, 0x35, 0x87, 0xCF],
+            _ => unimplemented!(),
+        }
+    }
+
+    fn xpriv_prefix(&self) -> &'static [u8; 4] {
+        match *self {
+            Networks::Bitcoin => &[0x04, 0x88, 0xAD, 0xE4],
+            Networks::Testnet | Networks::Regtest => &[0x04, 0x35, 0x83, 0x94],
+            _ => unimplemented!(),
+        }
+    }
+
     fn magic(&self) -> u32 {
         match *self {
             // https://github.com/bitcoin/bitcoin/blob/ce650182f4d9847423202789856e6e5f499151f8/src/chainparams.cpp#L115
@@ -481,6 +503,14 @@ impl NetworkConstants for BitcoinNetworks {
         self.to_networks().p2sh_prefix()
     }
 
+    fn xpub_prefix(&self) -> &'static [u8; 4] {
+        self.to_networks().xpub_prefix()
+    }
+
+    fn xpriv_prefix(&self) -> &'static [u8; 4] {
+        self.to_networks().xpriv_prefix()
+    }
+
     fn magic(&self) -> u32 {
         self.to_networks().magic()
     }
@@ -605,6 +635,8 @@ mod tests {
             let _ = n.p2pk_prefix();
             let _ = n.p2pkh_prefix();
             let _ = n.p2sh_prefix();
+            let _ = n.xpub_prefix();
+            let _ = n.xpriv_prefix();
 
             let magic = n.magic();
             assert_eq!(n, BitcoinNetworks::from_magic(magic).unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,9 @@ pub trait NetworkConstants : Sized {
     /// Returns the prefix bytes for encoding xpriv keys
     fn xpriv_prefix(&self) -> &'static [u8; 4];
 
+    /// Returns the prefix byte for encoding private keys as WIF
+    fn wif_prefix(&self) -> u8;
+
     /// Returns the network's magic bytes
     fn magic(&self) -> u32;
 
@@ -327,6 +330,14 @@ impl NetworkConstants for Networks {
         }
     }
 
+    fn wif_prefix(&self) -> u8 {
+        match *self {
+            Networks::Bitcoin => 128,
+            Networks::Testnet | Networks::Regtest => 239,
+            _ => unimplemented!(),
+        }
+    }
+
     fn magic(&self) -> u32 {
         match *self {
             // https://github.com/bitcoin/bitcoin/blob/ce650182f4d9847423202789856e6e5f499151f8/src/chainparams.cpp#L115
@@ -511,6 +522,10 @@ impl NetworkConstants for BitcoinNetworks {
         self.to_networks().xpriv_prefix()
     }
 
+    fn wif_prefix(&self) -> u8 {
+        self.to_networks().wif_prefix()
+    }
+
     fn magic(&self) -> u32 {
         self.to_networks().magic()
     }
@@ -637,6 +652,7 @@ mod tests {
             let _ = n.p2sh_prefix();
             let _ = n.xpub_prefix();
             let _ = n.xpriv_prefix();
+            let _ = n.wif_prefix();
 
             let magic = n.magic();
             assert_eq!(n, BitcoinNetworks::from_magic(magic).unwrap());

--- a/src/networks.rs
+++ b/src/networks.rs
@@ -156,7 +156,7 @@ impl NetworkConstants for BitcoinTestnet {
     }
 
     fn name(&self) -> &'static str {
-        "testnet"
+        "bitcoin-testnet"
     }
 
     fn network_type(&self) -> NetworkType {
@@ -231,7 +231,7 @@ impl NetworkConstants for BitcoinRegtest {
     }
 
     fn name(&self) -> &'static str {
-        "regtest"
+        "bitcoin-regtest"
     }
 
     fn network_type(&self) -> NetworkType {

--- a/src/networks.rs
+++ b/src/networks.rs
@@ -1,0 +1,271 @@
+    //! Contains the networks supported by this crate.
+    //!
+    //! A network is represented by a zero sized struct which implements `NetworkConstants`. When used
+    //! as function argument they should be passed as `&NetworkConstants` and if returned as result
+    //! they should be boxed `Box<NetworkConstants>`. Since they are zero-sized `Box` will not allocate.
+    //!
+    //! The reason for this design decision is to avoid complete matching over some enum implementing
+    //! `NetworkConstants` which would make any expansion of the set of supported networks a breaking
+    //! change.
+
+use ::{ChainParams, NetworkConstants, NetworkType};
+use bitcoin_hashes::hex::FromHex;
+use bitcoin_hashes::sha256d::Sha256dHash;
+
+/// Represents the Bitcoin Mainnet
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Bitcoin {}
+
+/// Represents the Bitcoin Testnet
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct BitcoinTestnet {}
+
+/// Represents the Bitcoin Regtest network
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct BitcoinRegtest {}
+
+impl Bitcoin {
+    /// Create a new `Network` object representing Bitcoin
+    pub fn new() -> Box<NetworkConstants> {
+        Box::new(Bitcoin {})
+    }
+}
+
+impl BitcoinTestnet {
+    /// Create a new `Network` object representing BitcoinTestnet
+    pub fn new() -> Box<NetworkConstants> {
+        Box::new(BitcoinTestnet {})
+    }
+}
+
+impl BitcoinRegtest {
+    /// Create a new `Network` object representing BitcoinRegtest
+    pub fn new() -> Box<NetworkConstants> {
+        Box::new(BitcoinRegtest {})
+    }
+}
+
+impl NetworkConstants for Bitcoin {
+    fn hrp(&self) -> &'static str {
+        "bc"
+    }
+
+    fn p2pk_prefix(&self) -> u8 {
+        0
+    }
+
+    fn p2pkh_prefix(&self) -> u8 {
+        0
+    }
+
+    fn p2sh_prefix(&self) -> u8 {
+        5
+    }
+
+    fn xpub_prefix(&self) -> &'static [u8; 4] {
+        static PREFIX: [u8; 4] = [0x04u8, 0x88, 0xB2, 0x1E];
+        &PREFIX
+    }
+
+    fn xpriv_prefix(&self) -> &'static [u8; 4] {
+        static PREFIX: [u8; 4] = [0x04, 0x88, 0xAD, 0xE4];
+        &PREFIX
+    }
+
+    fn wif_prefix(&self) -> u8 {
+        128
+    }
+
+    fn magic(&self) -> u32 {
+        0xD9B4BEF9
+    }
+
+    fn name(&self) -> &'static str {
+        "bitcoin"
+    }
+
+    fn network_type(&self) -> NetworkType {
+        NetworkType::Mainnet
+    }
+
+    fn chain_params(&self) -> ChainParams {
+        ChainParams {
+            bip16_time: 1333238400,                 // Apr 1 2012
+            bip34_height: 227931, // 000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8
+            bip65_height: 388381, // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
+            bip66_height: 363725, // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+            rule_change_activation_threshold: 1916, // 95%
+            miner_confirmation_window: 2016,
+            pow_limit: [
+                0xffffffffffffffffu64,
+                0xffffffffffffffffu64,
+                0xffffffffffffffffu64,
+                0x00000000ffffffffu64,
+            ],
+            pow_target_spacing: 10 * 60,            // 10 minutes.
+            pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+            allow_min_difficulty_blocks: false,
+            no_pow_retargeting: false,
+        }
+    }
+
+    fn genesis_block(&self) -> Sha256dHash {
+        Sha256dHash::from_hex(
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+        ).expect("static hex string, tested")
+    }
+
+    fn clone_boxed(&self) -> Box<NetworkConstants> {
+        Self::new()
+    }
+}
+
+impl NetworkConstants for BitcoinTestnet {
+    fn hrp(&self) -> &'static str {
+        "tb"
+    }
+
+    fn p2pk_prefix(&self) -> u8 {
+        111
+    }
+
+    fn p2pkh_prefix(&self) -> u8 {
+        111
+    }
+
+    fn p2sh_prefix(&self) -> u8 {
+        196
+    }
+
+    fn xpub_prefix(&self) -> &'static [u8; 4] {
+        static PREFIX: [u8; 4] = [0x04u8, 0x35, 0x87, 0xCF];
+        &PREFIX
+    }
+
+    fn xpriv_prefix(&self) -> &'static [u8; 4] {
+        static PREFIX: [u8; 4] = [0x04, 0x35, 0x83, 0x94];
+        &PREFIX
+    }
+
+    fn wif_prefix(&self) -> u8 {
+        239
+    }
+
+    fn magic(&self) -> u32 {
+        0x0709110B
+    }
+
+    fn name(&self) -> &'static str {
+        "testnet"
+    }
+
+    fn network_type(&self) -> NetworkType {
+        NetworkType::Testnet
+    }
+
+    fn chain_params(&self) -> ChainParams {
+        ChainParams {
+            bip16_time: 1333238400,                 // Apr 1 2012
+            bip34_height: 21111, // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
+            bip65_height: 581885, // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
+            bip66_height: 330776, // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+            rule_change_activation_threshold: 1512, // 75%
+            miner_confirmation_window: 2016,
+            pow_limit: [
+                0xffffffffffffffffu64,
+                0xffffffffffffffffu64,
+                0xffffffffffffffffu64,
+                0x00000000ffffffffu64,
+            ],
+            pow_target_spacing: 10 * 60,            // 10 minutes.
+            pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+            allow_min_difficulty_blocks: true,
+            no_pow_retargeting: false,
+        }
+    }
+
+    fn genesis_block(&self) -> Sha256dHash {
+        Sha256dHash::from_hex(
+            "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
+        ).expect("static hex string, tested")
+    }
+
+    fn clone_boxed(&self) -> Box<NetworkConstants> {
+        Self::new()
+    }
+}
+
+impl NetworkConstants for BitcoinRegtest {
+    fn hrp(&self) -> &'static str {
+        "bcrt"
+    }
+
+    fn p2pk_prefix(&self) -> u8 {
+        111
+    }
+
+    fn p2pkh_prefix(&self) -> u8 {
+        111
+    }
+
+    fn p2sh_prefix(&self) -> u8 {
+        196
+    }
+
+    fn xpub_prefix(&self) -> &'static [u8; 4] {
+        static PREFIX: [u8; 4] = [0x04u8, 0x35, 0x87, 0xCF];
+        &PREFIX
+    }
+
+    fn xpriv_prefix(&self) -> &'static [u8; 4] {
+        static PREFIX: [u8; 4] = [0x04, 0x35, 0x83, 0x94];
+        &PREFIX
+    }
+
+    fn wif_prefix(&self) -> u8 {
+        239
+    }
+
+    fn magic(&self) -> u32 {
+        0xDAB5BFFA
+    }
+
+    fn name(&self) -> &'static str {
+        "regtest"
+    }
+
+    fn network_type(&self) -> NetworkType {
+        NetworkType::Regtest
+    }
+
+    fn chain_params(&self) -> ChainParams {
+        ChainParams {
+            bip16_time: 1333238400,  // Apr 1 2012
+            bip34_height: 100000000, // not activated on regtest
+            bip65_height: 1351,
+            bip66_height: 1251,                    // used only in rpc tests
+            rule_change_activation_threshold: 108, // 75%
+            miner_confirmation_window: 144,
+            pow_limit: [
+                0xffffffffffffffffu64,
+                0xffffffffffffffffu64,
+                0xffffffffffffffffu64,
+                0x7fffffffffffffffu64,
+            ],
+            pow_target_spacing: 10 * 60,            // 10 minutes.
+            pow_target_timespan: 14 * 24 * 60 * 60, // 2 weeks.
+            allow_min_difficulty_blocks: true,
+            no_pow_retargeting: true,
+        }
+    }
+
+    fn genesis_block(&self) -> Sha256dHash {
+        Sha256dHash::from_hex(
+            "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
+        ).expect("static hex string, tested")
+    }
+
+    fn clone_boxed(&self) -> Box<NetworkConstants> {
+        Self::new()
+    }
+}


### PR DESCRIPTION
extract constants from:

 * rust-bech32-bitcoin
 * rust-bitcoin

and combine them in one crate, so we can avoid redundant implementations of the same constants.