### PR TITLE
Add Eq, Ord and Hash impl for Network based on name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,14 @@ impl Network {
     }
 }
 
+impl PartialEq for Network {
+    fn eq(&self, other: &Network) -> bool {
+        self.name() == other.name()
+    }
+}
+
+impl Eq for Network {}
+
 impl Clone for Network {
     fn clone(&self) -> Self {
         Self::from_box(self.0.clone_boxed())
@@ -219,5 +227,16 @@ mod tests {
             let _ = n.genesis_block();
             let _ = n.clone_boxed();
         }
+    }
+
+    #[test]
+    fn equality() {
+        assert_eq!(Network::bitcoin(), Network::bitcoin());
+        assert_eq!(Network::bitcoin_testnet(), Network::bitcoin_testnet());
+        assert_eq!(Network::bitcoin_regtest(), Network::bitcoin_regtest());
+
+        assert_ne!(Network::bitcoin(), Network::bitcoin_testnet());
+        assert_ne!(Network::bitcoin(), Network::bitcoin_regtest());
+        assert_ne!(Network::bitcoin_testnet(), Network::bitcoin_regtest());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,9 @@ extern crate bitcoin_hashes;
 
 use bitcoin_hashes::sha256d;
 use std::{fmt, ops};
+use std::cmp::Ordering;
+use std::hash::Hash;
+use std::hash::Hasher;
 
 pub mod networks;
 
@@ -79,7 +82,25 @@ impl PartialEq for Network {
     }
 }
 
+impl PartialOrd for Network {
+    fn partial_cmp(&self, other: &Network) -> Option<Ordering> {
+        self.name().partial_cmp(other.name())
+    }
+}
+
 impl Eq for Network {}
+
+impl Ord for Network {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name().cmp(other.name())
+    }
+}
+
+impl Hash for Network {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name().hash(state)
+    }
+}
 
 impl Clone for Network {
     fn clone(&self) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,12 @@ impl Clone for Network {
     }
 }
 
+impl fmt::Display for Network {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        f.write_str(self.name())
+    }
+}
+
 impl ops::Deref for Network {
     type Target = Box<NetworkConstants>;
 


### PR DESCRIPTION
Some structs containing `Network` in `rust-bitcoin` derive a bunch of standard traits which means `Network` also has to implement them.

At first I didn't want to do this because I know of no good way to do this nicely on stable, let alone 1.14.0 (I'd like to use `Any::get_type_id()` since all other attributes aren't guaranteed to be unique and comparing all of them seems a bit wasteful). But since it's required now I decided to use `name`, which could be seen as the primary key for `Network`, to determine equality of `Network`s.